### PR TITLE
New connection is initialized twice

### DIFF
--- a/rpyc/utils/server.py
+++ b/rpyc/utils/server.py
@@ -177,7 +177,6 @@ class Server(object):
             config = dict(self.protocol_config, credentials = credentials)
             conn = Connection(self.service, Channel(SocketStream(sock)),
                 config = config, _lazy = True)
-            conn._init_service()
             conn.serve_all()
         finally:
             self.logger.info("goodbye [%s]:%s", h, p)


### PR DESCRIPTION
In "rpyc.utils.server.Server._serve_client" new Connections are created and initialized when a client connects:

```
class Server(object):
    ...
    def _serve_client(self, sock, credentials):
        ...
        conn = Connection(self.service, Channel(SocketStream(sock)),
            config = config, _lazy = True)
        conn._init_service()
        conn.serve_all()
```

However in the constructor of rpyc.core.Connection the connection is initialized a second time (conditionally):

```
class Connection(object):
    def __init__(self, service, channel, config = {}, _lazy = False):
        ...
        if not _lazy:
            self._init_service()
```
