### PR TITLE
Here is a fix for #52

### DIFF
--- a/rpyc/__init__.py
+++ b/rpyc/__init__.py
@@ -46,7 +46,7 @@ from rpyc.core import (SocketStream, TunneledSocketStream, PipeStream, Channel,
     AsyncResultTimeout, VoidService, SlaveService)
 from rpyc.utils.factory import (connect_stream, connect_channel, connect_pipes,
     connect_stdpipes, connect, ssl_connect, discover, connect_by_service, connect_subproc, 
-    connect_thread)
+    connect_thread, ssh_connect)
 from rpyc.utils.helpers import async, timed, buffiter, BgServingThread, restricted
 from rpyc.utils import classic
 from rpyc.version import version, version_string, release_date

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -29,8 +29,8 @@ class Test_Ssh(unittest.TestCase):
             t.setDaemon(True)
             t.start()
             time.sleep(0.5)
-            sshctx = SshContext("localhost")
-            self.conn = rpyc.classic.ssh_connect(sshctx, self.server.port)
+            self.sshctx = SshContext("localhost")
+            self.conn = rpyc.classic.ssh_connect(self.sshctx, self.server.port)
 
     def tearDown(self):
         self.conn.close()
@@ -42,6 +42,11 @@ class Test_Ssh(unittest.TestCase):
         self.conn.modules.sys.stdout.write("hello over ssh\n")
         self.conn.modules.sys.stdout.flush()
 
+    def test_connect(self):
+        conn2 = rpyc.ssh_connect(self.sshctx, self.server.port, 
+                                 service=SlaveService)
+        conn2.modules.sys.stdout.write("hello through rpyc.ssh_connect()\n")
+        conn2.modules.sys.stdout.flush()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Issue 52: missing rpyc.ssh_connect() https://github.com/tomerfiliba/rpyc/issues/52

I fixed the issue and added a unit test that fails with the previous code. The fix is trivial, and the test makes up most of the patch. It can easily be omitted by ignoring the changes to tests/test_ssh.py.
