### PR TITLE
Support for the python multiprocess library

### DIFF
--- a/rpyc/utils/classic.py
+++ b/rpyc/utils/classic.py
@@ -127,8 +127,8 @@ def connect_thread():
 
 def connect_multiprocess(args = {}):
     """
-    Starts a SlaveService on a multiporcess process and connects to it. 
-    Useful for testing purposes and running multicore c ode thats uses shared
+    Starts a SlaveService on a multiprocess process and connects to it.
+    Useful for testing purposes and running multicore code thats uses shared
     memory. See :func:`rpyc.utils.factory.connect_multiprocess`
     
     :returns: an RPyC connection exposing ``SlaveService``

--- a/rpyc/utils/factory.py
+++ b/rpyc/utils/factory.py
@@ -240,15 +240,15 @@ def connect_thread(service = VoidService, config = {}, remote_service = VoidServ
 
 def connect_multiprocess(service = VoidService, config = {}, remote_service = VoidService, remote_config = {}, args={}):
     """starts an rpyc server on a new process, bound to an arbitrary port, 
-    and connects to it over a socket. Basically a copy of connect_thread.
-    Hopwever if args is used and if these are shared memory then changes
-    will be bi-directional. That is we now have access to shsred memmory.
+    and connects to it over a socket. Basically a copy of connect_thread().
+    However if args is used and if these are shared memory then changes
+    will be bi-directional. That is we now have access to shared memmory.
     
     :param service: the local service to expose (defaults to Void)
     :param config: configuration dict
     :param server_service: the remote service to expose (of the server; defaults to Void)
     :param server_config: remote configuration dict (of the server)
-    :param args: namespace dict of local vars to pass in
+    :param args: dict of local vars to pass to new connection, form {'name':var}
     
     Contributed by *@tvanzyl*
     """


### PR DESCRIPTION
Hi Terence Here.

Really love the project use it a lot.

I have added some changes that allow the use of the python multiprocessing package instead of the subpocess package to spawn new connections. This allows for the use of multiprocessing.sharedctypes as shared memory and should be supported across MS$ and *NIX. Although I have only tested on Linux.
