### PR TITLE
Fixes AttributeError exception on comparison in python 2.6.5 or greater as __cmp__ function was removed leaving only rich comparison functions (e.g. __lt__, __gt__)

### DIFF
--- a/rpyc/core/protocol.py
+++ b/rpyc/core/protocol.py
@@ -512,7 +512,7 @@ class Connection(object):
         obj = self._local_objects[oid]
         try:
             return type(obj).__cmp__(obj, other)
-        except TypeError:
+        except (AttributeError, TypeError):
             return NotImplemented
     def _handle_hash(self, oid):
         return hash(self._local_objects[oid])


### PR DESCRIPTION
Steps to reproduce:
Open python 2.6.5 or greater (I use 2.7)
execute code:

> import rpyc
> c = rpyc.classic.connect_subproc()
> c.modules.sys.argv == None

As a result the exception is raised

> AttributeError: type object 'list' has no attribute '**cmp**'
