### PR TITLE
Fix exception types raised from __getattr__ or __getattribute__

### DIFF
--- a/rpyc/core/stream.py
+++ b/rpyc/core/stream.py
@@ -58,12 +58,14 @@ class Stream(object):
         """
         raise NotImplementedError()
 
-
+class EOF_and_AttributeError(EOFError, AttributeError):
+    pass
+    
 class ClosedFile(object):
     """Represents a closed file object (singleton)"""
     __slots__ = ()
     def __getattr__(self, name):
-        raise EOFError("stream has been closed")
+        raise EOF_and_AttributeError("stream has been closed")
     def close(self):
         pass
     @property

--- a/rpyc/lib/__init__.py
+++ b/rpyc/lib/__init__.py
@@ -9,7 +9,7 @@ class MissingModule(object):
     def __init__(self, name):
         self.__name = name
     def __getattr__(self, name):
-        raise ImportError("module %r not found" % (self.__name,))
+        raise AttributeError("module %r not found" % (self.__name,))
     def __bool__(self):
         return False
     __nonzero__ = __bool__


### PR DESCRIPTION
Only raise instances of AttributeError from
**getattr** or **getattribute**.

There are a few cases, where RPyC raises exceptions other than AttributeError (or subclasses thereof) from **getattr** or **getattribute**. This breaks code, that uses i.e. getattr(object, name, default)  because getattr now raises an exception instead of returning "default".
