### PR TITLE
SocketStream: add support for unix domain sockets

### DIFF
--- a/rpyc/core/stream.py
+++ b/rpyc/core/stream.py
@@ -83,7 +83,7 @@ class SocketStream(Stream):
     MAX_IO_CHUNK = 8000
     def __init__(self, sock):
         self.sock = sock
-    
+        
     @classmethod
     def _connect(cls, host, port, family = socket.AF_INET, socktype = socket.SOCK_STREAM,
             proto = 0, timeout = 3, nodelay = False):
@@ -112,6 +112,19 @@ class SocketStream(Stream):
         if kwargs.pop("ipv6", False):
             kwargs["family"] = socket.AF_INET6
         return cls(cls._connect(host, port, **kwargs))
+
+    @classmethod
+    def unix_connect(cls, path, timeout = 3):
+        """factory method that creates a ``SocketStream `` over a unix domain socket
+        located in *path*
+
+        :param path: the path to the unix domain socket
+        :param timeout: socket timeout
+        """
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(timeout)
+        s.connect(path)
+        return cls(s)
 
     @classmethod
     def ssl_connect(cls, host, port, ssl_kwargs, **kwargs):

--- a/rpyc/utils/classic.py
+++ b/rpyc/utils/classic.py
@@ -64,6 +64,16 @@ def connect(host, port = DEFAULT_SERVER_PORT, ipv6 = False):
     """
     return factory.connect(host, port, SlaveService, ipv6 = ipv6)
 
+def unix_connect(path):
+    """
+    Creates a socket connection to the given host and port.
+
+    :param path: the path to the unix domain socket
+    
+    :returns: an RPyC connection exposing ``SlaveService``
+    """
+    return factory.unix_connect(path, SlaveService)
+    
 def ssl_connect(host, port = DEFAULT_SERVER_SSL_PORT, keyfile = None,
         certfile = None, ca_certs = None, cert_reqs = None, ssl_version = None, 
         ciphers = None, ipv6 = False):

--- a/rpyc/utils/factory.py
+++ b/rpyc/utils/factory.py
@@ -88,7 +88,20 @@ def connect(host, port, service = VoidService, config = {}, ipv6 = False):
     """
     s = SocketStream.connect(host, port, ipv6 = ipv6)
     return connect_stream(s, service, config)
+    
+def unix_connect(path, service = VoidService, config = {}):
+    """
+    creates a socket-connection to the given host and port
 
+    :param path: the path to the unix domain socket
+    :param service: the local service to expose (defaults to Void)
+    :param config: configuration dict
+
+    :returns: an RPyC connection
+    """
+    s = SocketStream.unix_connect(path)
+    return connect_stream(s, service, config)
+    
 def ssl_connect(host, port, keyfile = None, certfile = None, ca_certs = None,
         cert_reqs = None, ssl_version = None, ciphers = None,
         service = VoidService, config = {}, ipv6 = False):

--- a/tests/test_threaded_server.py
+++ b/tests/test_threaded_server.py
@@ -1,16 +1,24 @@
 import rpyc
 import time
+import tempfile
 from rpyc.utils.server import ThreadedServer
 from rpyc import SlaveService
 import threading
 import unittest
 
+class BaseServerTest(object):
 
-class Test_ThreadedServer(unittest.TestCase):
+    def _create_server(self):
+        raise NotImplementedError
+
+    def _create_client(self):
+        raise NotImplementedError
+        
     def setUp(self):
-        self.server = ThreadedServer(SlaveService, port=18878, auto_register=False)
+        self.server = self._create_server()
         self.server.logger.quiet = False
         t = threading.Thread(target=self.server.start)
+        t.setDaemon(True)
         t.start()
         time.sleep(0.5)
 
@@ -18,7 +26,7 @@ class Test_ThreadedServer(unittest.TestCase):
         self.server.close()
 
     def test_conenction(self):
-        c = rpyc.classic.connect("localhost", port=18878)
+        c = self._create_client()
         print( c.modules.sys )
         print( c.modules["xml.dom.minidom"].parseString("<a/>") )
         c.execute("x = 5")
@@ -26,6 +34,23 @@ class Test_ThreadedServer(unittest.TestCase):
         self.assertEqual(c.eval("1+x"), 6)
         c.close()
 
+class Test_ThreadedServer(BaseServerTest, unittest.TestCase):
 
+    def _create_server(self):
+        return ThreadedServer(SlaveService, port=18878, auto_register=False)
+
+    def _create_client(self):
+        return rpyc.classic.connect("localhost", port=18878)    
+
+class Test_ThreadedServerOverUnixSocket(BaseServerTest, unittest.TestCase):
+
+    socket_path = tempfile.mktemp()
+    
+    def _create_server(self):
+        return ThreadedServer(SlaveService, socket_path=self.socket_path, auto_register=False)
+
+    def _create_client(self):
+        return rpyc.classic.unix_connect(self.socket_path)
+        
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added client, server and a test.

The server code isn't very pretty as it was highly oriented to networking. I didn't want to make a bigger refactoring as it won't be backward compatible (and I'd be happy to see it in 3.2).

It'd be perfectly fine if you decide not to merge.. I can offer a prettier solution to 3.3 (specifically add separate constructors to the Server class instead of tons of mutually exclusive arguments)
