### PR TITLE
Register again after short delay if registration does not work

### DIFF
--- a/rpyc/utils/registry.py
+++ b/rpyc/utils/registry.py
@@ -350,7 +350,7 @@ class UDPRegistryClient(RegistryClient):
                     rip, rport = address[:2]
                 except socket.timeout:
                     self.logger.warn("no registry acknowledged")
-                    break
+                    return False
                 if rport != self.port:
                     continue
                 try:
@@ -359,9 +359,10 @@ class UDPRegistryClient(RegistryClient):
                     continue
                 if reply == "OK":
                     self.logger.info("registry %s:%s acknowledged", rip, rport)
-                    break
+                    return True
             else:
                 self.logger.warn("no registry acknowledged")
+                return False
         finally:
             sock.close()
 
@@ -427,19 +428,21 @@ class TCPRegistryClient(RegistryClient):
                 sock.send(data)
             except (socket.error, socket.timeout):
                 self.logger.warn("could not connect to registry")
-                return
+                return False
             try:
                 data = sock.recv(MAX_DGRAM_SIZE)
             except socket.timeout:
                 self.logger.warn("registry did not acknowledge")
-                return
+                return False
             try:
                 reply = brine.load(data)
             except Exception:
                 self.logger.warn("received corrupted data from registry")
-                return
+                return False
             if reply == "OK":
                 self.logger.info("registry %s:%s acknowledged", self.ip, self.port)
+
+            return True
         finally:
             sock.close()
 


### PR DESCRIPTION
In my setup the registration on the RegistryServer does not always work the first time. However, if noticed, that retrying a second time makes the registration happen as expected.

The following code changes check if calling `register` on the `TCPRegistryClient` or `UDPRegistryClient` was successful. If it was not, than another registration attempt is made after 1 s of delay.
