### PR TITLE
Added ability to add custom service and fixed MultiServerDeployment

### DIFF
--- a/rpyc/utils/zerodeploy.py
+++ b/rpyc/utils/zerodeploy.py
@@ -8,7 +8,8 @@ import rpyc
 import socket
 from rpyc.core.service import VoidService
 from rpyc.core.stream import SocketStream
-from inspect import getsource
+from os import path
+from inspect import getfile
 try:
     from plumbum import local, ProcessExecutionError
     from plumbum.path import copy
@@ -44,11 +45,11 @@ except Exception:
     pass
 
 sys.path.insert(0, here)
-from $MODULE$ import $SERVER$ as ServerCls
-from rpyc import $SERVICE_CLS$
+from %(module)s import %(server)s as ServerCls
+%(serviceClsImportStr)s
 
-t = ServerCls($SERVICE_CLS_NAME$, hostname = "localhost", port = 0, reuse_addr = True)
-sys.stdout.write("%s\n" % (t.port,))
+t = ServerCls(%(clsName)s, hostname = "localhost", port = 0, reuse_addr = True)
+sys.stdout.write("%%s\n" %% (t.port,))
 sys.stdout.flush()
 
 try:
@@ -61,8 +62,9 @@ finally:
     thd.join(2)
 """
 
-class DeployedServer(object):
+class BaseDeployedServer(object):
     """
+    - Base class for deployed server 
     Sets up a temporary, short-lived RPyC deployment on the given remote machine. It will: 
     
     1. Create a temporary directory on the remote machine and copy RPyC's code 
@@ -81,46 +83,23 @@ class DeployedServer(object):
     :param server_class: the server to create (e.g., ``"ThreadedServer"``, ``"ForkingServer"``)
     """
     
-    def __init__(self, remote_machine, service_class = "SlaveService", server_class = "rpyc.utils.server.ThreadedServer"):
+    def __init__(self, remote_machine, server_class = "rpyc.utils.server.ThreadedServer"):
         self.proc = None
         self.tun = None
+        self.remote_port = None        
         self.remote_machine = remote_machine
-        self._tmpdir_ctx = None
-        rpyc_root = local.path(rpyc.__file__).dirname
+        self.remote_machine_type = remote_machine.__class__.__name__
+        self.srvModuleName, self.srvClsName = server_class.rsplit(".", 1)
         self._tmpdir_ctx = remote_machine.tempdir()
-        tmp = self._tmpdir_ctx.__enter__()
-        copy(rpyc_root, tmp)
-        script = (tmp / "deployed-rpyc.py")
-        modname, clsname = server_class.rsplit(".", 1)
-        if service_class == "SlaveService":
-            scriptServiceCls = service_class
-            scriptServiceClsName = service_class
+        self._tmpdir_path = self._tmpdir_ctx.__enter__()        
+        self._script_path = ( self._tmpdir_path / "deployed-rpyc.py")
+        #Copy modules dir
+        if self.remote_machine_type ==  "SshMachine":
+            rpyc_root = local.path(rpyc.__file__).dirname
         else:
-            scriptServiceCls = "Service\n"+getsource(service_class)
-            scriptServiceClsName = service_class.__name__
-        script.write(SERVER_SCRIPT.replace("$MODULE$", modname).replace("$SERVER$", clsname).replace("$SERVICE_CLS$", scriptServiceCls).replace("$SERVICE_CLS_NAME$", scriptServiceClsName))
-        self.proc = remote_machine.python.popen(script, new_session = True)        
-        line = ""
-        try:
-            line = self.proc.stdout.readline()
-            self.remote_port = int(line.strip())
-        except Exception:
-            try:
-                self.proc.terminate()
-            except Exception:
-                pass
-            stdout, stderr = self.proc.communicate()
-            raise ProcessExecutionError(self.proc.argv, self.proc.returncode, line + stdout, stderr)
-        
-        if hasattr(remote_machine, "connect_sock"):
-            # Paramiko: use connect_sock() instead of tunnels
-            self.local_port = None
-        else:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.bind(("localhost", 0))
-            self.local_port = s.getsockname()[1]
-            s.close()
-            self.tun = remote_machine.tunnel(self.local_port, self.remote_port)
+            rpyc_root = local.path(rpyc.__file__).up(2)
+        copy(rpyc_root, self._tmpdir_path)
+        #create script        
 
     def __del__(self):
         self.close()
@@ -148,6 +127,7 @@ class DeployedServer(object):
             except Exception:
                 pass
             self._tmpdir_ctx = None
+            self._tmpdir_path = None
     
     def connect(self, service = VoidService, config = {}):
         """Same as :func:`connect <rpyc.utils.factory.connect>`, but with the ``host`` and ``port`` 
@@ -168,17 +148,80 @@ class DeployedServer(object):
             return rpyc.classic.connect_stream(stream)
         else:
             return rpyc.classic.connect("localhost", self.local_port)
+    def _executeRemoteScript(self):
+        """ Executes deployed rpyc script on destination """
+        self.proc = self.remote_machine.python.popen(self._script_path, new_session = True)
+    def _getRemotePort(self):
+        line = ""
+        try:
+            line = self.proc.stdout.readline()                        
+            self.remote_port = int(line.strip())            
+        except Exception:
+            try:
+                self.proc.terminate()
+            except Exception:
+                pass
+            stdout, stderr = self.proc.communicate()
+            raise ProcessExecutionError(self.proc.argv, self.proc.returncode, line + stdout, stderr)
+    def _createTunnel(self):        
+        if hasattr(self.remote_machine, "connect_sock"):
+            # Paramiko: use connect_sock() instead of tunnels
+            self.local_port = None
+        else:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.bind(("localhost", 0))
+            self.local_port = s.getsockname()[1]
+            s.close()
+            self.tun = self.remote_machine.tunnel(self.local_port, self.remote_port)          
 
+class DeployedServer(BaseDeployedServer):
+    def __init__(self, remote_machine, server_class = "rpyc.utils.server.ThreadedServer"):
+        BaseDeployedServer.__init__(self, remote_machine, server_class)
+        self._script_path.write(SERVER_SCRIPT%{ "module": self.srvModuleName, 
+                                                                            "server" : self.srvClsName,                                                                            
+                                                                            "serviceClsImportStr": "from rpyc import SlaveService",
+                                                                            "clsName" : "SlaveService"                                                                             
+                                                                         })                            
+        self._executeRemoteScript()
+        self._getRemotePort()
+        self._createTunnel()
 
+class CustomDeployedServer(BaseDeployedServer):
+    """ 
+    This deployed server uses service model. Service class should be located in different file.
+    CustomDeployedServer copies the file in which service is located and appropriately modifies the script that is run on remote server.
+    Custom service class should also be imported in the file where CustomDeployedServer object is used. 
+    For example: 
+              from rpyc_test_service import TestService
+              mach = SshMachine(<hostName>, user=<userName>)
+              server = CustomDeployedServer(remote_machine=mach, serviceCls = TestService)
+              conn1 = server.connect()
+    :param serviceCls: class of the custom service
+    """
+    def __init__(self, remote_machine, server_class = "rpyc.utils.server.ThreadedServer", serviceCls = None):
+        BaseDeployedServer.__init__(self, remote_machine, server_class)
+        serviceClsPath = local.path(getfile(serviceCls).replace(".pyc",".py"))
+        copy(serviceClsPath, self._tmpdir_path)
+        self._script_path.write(SERVER_SCRIPT%{ "module": self.srvModuleName, 
+                                                                            "server" : self.srvClsName,                                                                            
+                                                                            "serviceClsImportStr": "import "+serviceCls.__module__,
+                                                                            "clsName" : serviceCls.__module__+"."+serviceCls.__name__
+                                                                         })        
+        self._executeRemoteScript()
+        self._getRemotePort()        
+        self._createTunnel()
+                                  
+        
+        
 class MultiServerDeployment(object):
     """
     An 'aggregate' server deployment to multiple SSH machine. It deploys RPyC to each machine
     separately, but lets you manage them as a single deployment.
     """
-    def __init__(self, remote_machines,  service_class = "SlaveService", server_class = "rpyc.utils.server.ThreadedServer"):
+    def __init__(self, remote_machines, server_class = "rpyc.utils.server.ThreadedServer"):
         self.remote_machines = remote_machines
         # build the list incrementally, so we can clean it up if we have an exception
-        self.servers = [DeployedServer(mach, service_class, server_class) for mach in remote_machines]
+        self.servers = [DeployedServer(mach, server_class) for mach in remote_machines]
     
     def __del__(self):
         self.close()


### PR DESCRIPTION
Usage:
   Custom service: just pass service class to the DeployedServer,
   if no class passed it uses SlaveService by default
Fixes:
   MultiServerDeployment class:  added support for passing custom defined service class too.
