### PR TITLE
Update tut5.rst

### DIFF
--- a/docs/tutorial/tut5.rst
+++ b/docs/tutorial/tut5.rst
@@ -119,7 +119,7 @@ consider the following ``FileMonitor`` example -- it monitors monitors a file
     import time
     from threading import Thread
     
-    class FileMonitorService(rpyc.Service):
+    class FileMonitorService(rpyc.SlaveService):
         class exposed_FileMonitor(object):   # exposing names is not limited to methods :)
             def __init__(self, filename, callback, interval = 1):
                 self.filename = filename


### PR DESCRIPTION
For rpyc 3.2.3, if FileMonitorService extends rpyc.Service, I get an error when attempting to connect: 'FileMonitorService' object has no attribute 'exposed_getmodule'

...However extending from rpyc.SlaveService makes the problem go away.
