### PR TITLE
Fix bug in return of SelectingPoll.poll()

### DIFF
--- a/rpyc/lib/compat.py
+++ b/rpyc/lib/compat.py
@@ -136,9 +136,10 @@ else:
         def poll(self, timeout = None):
             if not self.rlist and not self.wlist:
                 time.sleep(timeout)
+                return []  # need to return an empty array in this case
             else:
                 rl, wl, _ = select(self.rlist, self.wlist, (), timeout)
-            return [(fd, "r") for fd in rl] + [(fd, "w") for fd in wl]
+                return [(fd, "r") for fd in rl] + [(fd, "w") for fd in wl]
     
     poll = SelectingPoll
 


### PR DESCRIPTION
Selecting poll poll operation needs to return an empty array if no file descriptors are registered. You can't iterate over local variables (rl, wl) if they are not defined, so moved the original return statement into the else block and put an explicit 'return []' under the empty file descriptor sets condition.
