### PR TITLE
Teleport functions' keyword-only argument defaults

### DIFF
--- a/rpyc/utils/teleportation.py
+++ b/rpyc/utils/teleportation.py
@@ -1,9 +1,5 @@
 import opcode
-import sys
-try:
-    import __builtin__
-except ImportError:
-    import builtins as __builtin__  # noqa: F401
+
 from rpyc.lib.compat import is_py_gte38
 from types import CodeType, FunctionType
 from rpyc.core import brine, netref
@@ -67,16 +63,16 @@ def _export_codeobj(cobj):
 
 
 def export_function(func):
-    func_closure = func.__closure__
-    func_code = func.__code__
-    func_defaults = func.__defaults__
+    closure = func.__closure__
+    code = func.__code__
+    defaults = func.__defaults__
 
-    if func_closure:
+    if closure:
         raise TypeError("Cannot export a function closure")
-    if not brine.dumpable(func_defaults):
-        raise TypeError("Cannot export a function with non-brinable defaults (func_defaults)")
+    if not brine.dumpable(defaults):
+        raise TypeError("Cannot export a function with non-brinable defaults (__defaults__)")
 
-    return func.__name__, func.__module__, func_defaults, _export_codeobj(func_code)[1]
+    return func.__name__, func.__module__, defaults, _export_codeobj(code)[1]
 
 
 def _import_codetup(codetup):

--- a/tests/test_teleportation.py
+++ b/tests/test_teleportation.py
@@ -101,8 +101,8 @@ class TeleportationTest(unittest.TestCase):
             pow38 = lambda x, y : x ** y  # noqa
             export37 = get37_schema(pow37.__code__)
             export38 = get38_schema(pow38.__code__)
-            schema37 = (pow37.__name__, pow37.__module__, pow37.__defaults__, export37)
-            schema38 = (pow38.__name__, pow38.__module__, pow38.__defaults__, export38)
+            schema37 = (pow37.__name__, pow37.__module__, pow37.__defaults__, pow37.__kwdefaults__, export37)
+            schema38 = (pow38.__name__, pow38.__module__, pow38.__defaults__, pow38.__kwdefaults__, export38)
             pow37_netref = self.conn.modules["rpyc.utils.teleportation"].import_function(schema37)
             pow38_netref = self.conn.modules["rpyc.utils.teleportation"].import_function(schema38)
             self.assertEqual(pow37_netref(2, 3), pow37(2, 3))

--- a/tests/test_teleportation.py
+++ b/tests/test_teleportation.py
@@ -26,6 +26,14 @@ def f(a):
     return g
 
 
+def defaults(a=5, b="hi", c=(5.5, )):
+    return a, b, c
+
+
+def kwdefaults(pos=5, *, a=42, b="bye", c=(12.4, )):
+    return pos, a, b, c
+
+
 def h(a):
     import os
     return a * os.getpid()
@@ -81,6 +89,14 @@ class TeleportationTest(unittest.TestCase):
         bar_ = teleport_function(self.conn, bar)
         self.assertEqual(foo_(), 43)
         self.assertEqual(bar_(), 42)
+
+    def test_defaults(self):
+        defaults_ = teleport_function(self.conn, defaults)
+        self.assertEqual(defaults_(), defaults())
+
+    def test_kwdefaults(self):
+        kwdefaults_ = teleport_function(self.conn, kwdefaults)
+        self.assertEqual(kwdefaults_(), kwdefaults())
 
     def test_compat(self):  # assumes func has only brineable types
 


### PR DESCRIPTION
Adds support for teleportation of function defaults of the type `def f(*, b=5)` (keyword-only argument defaults)

Note that the new code I included is not Python 2 compatible. I thought it's okay to do saw because I noticed you have dropped Python 2 support (7afaec2219993dd07a5c17f2cbb551a11b67c619).

Also - this breaks teleportation compatibility across different RPyC versions. Is this a feature we try to maintain? If so, I can see how to add such support.