### PR TITLE
Lookup classes in normalized builtins before trying sys.modules

### DIFF
--- a/tests/test_netref_hierachy.py
+++ b/tests/test_netref_hierachy.py
@@ -43,6 +43,9 @@ class MyService(rpyc.Service):
     def exposed_instance(self, inst, cls):
         return isinstance(inst, cls)
 
+    def exposed_getnonetype(self):
+        return type(None)
+
 
 class Test_Netref_Hierarchy(unittest.TestCase):
 
@@ -95,6 +98,16 @@ class Test_Netref_Hierarchy(unittest.TestCase):
         conn.root
         remote_list = conn.root.getlist()
         self.assertTrue(conn.root.instance(remote_list, list))
+        conn.close()
+
+    def test_instancecheck_none(self):
+        """
+        test for the regression reported in https://github.com/tomerfiliba-org/rpyc/issues/426
+        """
+        service = MyService()
+        conn = rpyc.connect_thread(remote_service=service)
+        remote_NoneType = conn.root.getnonetype()
+        self.assertTrue(isinstance(None, remote_NoneType))
         conn.close()
 
     def test_StandardError(self):


### PR DESCRIPTION
This logic was removed in b683c257146, possibly under the assumption  that all builtins exist under the `builtins` module - but this assumption is not correct, since some builtins like "method" are not available as `builtins.method`.
That's what "_normalized_builtin_types" is for (which was unused until this fix).

Resolves the immediate issue in https://github.com/tomerfiliba-org/rpyc/issues/426, but IDK if it breaks anything else along the way :sweat_smile: 

Few notes:
1. Not tested, I just checked the specific issue described in #426. @comrumino please tell me what you think, afterwards I'll add some tests for this case (builtins not under `builtins`)
2. Another possible issue (that existed before): in the builtin case, this assignment `ns["__class__"] = _builtin_class` is done, but it's later assigned again: `ns['__class__'] = class_descriptor`, where `class_descriptor` is a `NetrefClass`. I tested both cases (with the override, and without) and I couldn't tell the difference. Perhaps the flow taken in `NetrefClass.__get__` is always to get the object and not its type? Need to see further. Either way, we should either skip the override, or remove the (unnecessary & misleading) first assignment. Wdyt?
3. If I understand correctly, the reason the change in b683c257146 did not break *all* builtins, is that all those available under `builtins` were still using their matching local builtin. In that case, we can probably narrow down `_normalized_builtin_types
` to contain only the builtins not accessible via `builtins`, like `types.BuiltinFunctionType` and `type(None)`, ... and possibly we should do another "sweep" on builtins to ensure that none were forgotten?

Marking as draft, until we decide on those discussions.