### PR TITLE
Preventing rpyc 5.x from installing on Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-if sys.version_info < (3, 6):
-    sys.exit("requires python 3.6 and up")
-
 here = os.path.dirname(__file__)
 exec(open(os.path.join(here, 'rpyc', 'version.py')).read())
 
@@ -43,6 +40,7 @@ setup(name="rpyc",
       #        ],
       #    ),
       platforms=["POSIX", "Windows"],
+      python_requires='>=3.6',
       use_2to3=False,
       zip_safe=False,
       long_description=open(os.path.join(here, "README.rst"), "r").read(),


### PR DESCRIPTION
Currently if you 'pip install rpyc' on Python 3.5, rpyc 5.0.0 will successfully install, but not work since it only supports Python 3.6+.

IIRC wheels don't actually contain or execute the setup.py.  So the "if sys.version_info < (3, 6): " never actually executes on the installing system.  The correct way is to specify python_requires.  More info here: https://packaging.python.org/guides/dropping-older-python-versions/

Any chance you would also be willing to pull or republish 5.0.0?  With this change, pip will instead select the previous version of rpyc that supports 3.5.  So ideally that would be 4.1.5 instead of 5.0.0.

Thanks a ton for maintaining rpyc!  We use it to test a bunch of embedded linux systems, many of which are sadly still on 3.5.