### PR TITLE
chunk_size Parameter was not passed to download_dir call and also to recusive download call

### DIFF
--- a/rpyc/utils/classic.py
+++ b/rpyc/utils/classic.py
@@ -221,7 +221,7 @@ def download(conn, remotepath, localpath, filter=None, ignore_invalid=False, chu
     :param chunk_size: the IO chunk size
     """
     if conn.modules.os.path.isdir(remotepath):
-        download_dir(conn, remotepath, localpath, filter)
+        download_dir(conn, remotepath, localpath, filter, chunk_size)
     elif conn.modules.os.path.isfile(remotepath):
         download_file(conn, remotepath, localpath, chunk_size)
     else:
@@ -246,7 +246,7 @@ def download_dir(conn, remotepath, localpath, filter=None, chunk_size=STREAM_CHU
         if not filter or filter(fn):
             rfn = conn.modules.os.path.join(remotepath, fn)
             lfn = os.path.join(localpath, fn)
-            download(conn, rfn, lfn, filter=filter, ignore_invalid=True)
+            download(conn, rfn, lfn, filter=filter, ignore_invalid=True, chunk_size=chunk_size)
 
 
 def upload_package(conn, module, remotepath=None, chunk_size=STREAM_CHUNK):


### PR DESCRIPTION
In case if you want download recursive directory the chunk_size Parameter was not passed to the underlying download call.

The behaviour is now the same as in upload case.
https://github.com/tomerfiliba-org/rpyc/blob/a62f258cc18a4bda131b8e2cb92944ba2b41ca2d/rpyc/utils/classic.py#L185
https://github.com/tomerfiliba-org/rpyc/blob/a62f258cc18a4bda131b8e2cb92944ba2b41ca2d/rpyc/utils/classic.py#L210
