### PR TITLE
Prevent auto_register in Server from being wrongly set to False

### DIFF
--- a/rpyc/utils/server.py
+++ b/rpyc/utils/server.py
@@ -252,7 +252,6 @@ class Server(object):
 
     def _register(self):
         if self.auto_register:
-            self.auto_register = False
             spawn(self._bg_register)
 
     def start(self):
@@ -565,7 +564,6 @@ class GeventServer(Server):
 
     def _register(self):
         if self.auto_register:
-            self.auto_register = False
             gevent.spawn(self._bg_register)
 
     def _accept_method(self, sock):


### PR DESCRIPTION
Resolves #441

The attribute `auto_register` in `Server` and its inherited classes is used to register/unregister the Server to a registry.
If set to `True`, it will : 
    1. set itself to `False` in the `_register()` method
    2. spawn `_bg_register()` in the `_register()` method
    3. call `registrar.unregister()` in the `close()` method

Actions `1` and `3` are conflicting because `1` will prevent `3` from ever happening.
By removing `1`,  the auto_register mechanism will work correctly, without any side-effects because it is not called anywhere else.

Test case : I haven't had time to add one yet, but if necessary I will look into it.