### PR TITLE
Added command on Registry to list all known services

### DIFF
--- a/bin/rpyc_registry.py
+++ b/bin/rpyc_registry.py
@@ -28,12 +28,15 @@ class RegistryServer(cli.Application):
     pruning_timeout = cli.SwitchAttr(["-t", "--timeout"], int,
                                      default=DEFAULT_PRUNING_TIMEOUT, help="Set a custom pruning timeout (in seconds)")
 
+    allow_listing = cli.SwitchAttr(["-l", "--listing"], bool, default=False, help="Enable/disable listing on registry")
+
     def main(self):
         if self.mode == "UDP":
             server = UDPRegistryServer(host='::' if self.ipv6 else '0.0.0.0', port=self.port,
-                                       pruning_timeout=self.pruning_timeout)
+                                       pruning_timeout=self.pruning_timeout, allow_listing=self.allow_listing)
         elif self.mode == "TCP":
-            server = TCPRegistryServer(port=self.port, pruning_timeout=self.pruning_timeout)
+            server = TCPRegistryServer(port=self.port, pruning_timeout=self.pruning_timeout,
+                                       allow_listing=self.allow_listing)
         setup_logger(self.quiet, self.logfile)
         server.start()
 

--- a/docs/docs/servers.rst
+++ b/docs/docs/servers.rst
@@ -138,8 +138,5 @@ Switches
   time is the amount of time the registry server will keep a previously-registered service, when
   it no longer sends timely keepalives. The default is 4 minutes (240 seconds).
 
-
-
-
-
-
+* ``-l``, ``--listing`` - Give a boolean indicating if registry should allow sending the list of its known services.
+  The default is False.

--- a/rpyc/utils/factory.py
+++ b/rpyc/utils/factory.py
@@ -225,6 +225,14 @@ def discover(service_name, host=None, registrar=None, timeout=2):
     return addrs
 
 
+def list_services(registrar=None, timeout=2):
+    services = ()
+    if registrar is None:
+        registrar = UDPRegistryClient(timeout=timeout)
+    services = registrar.list()
+    return services
+
+
 def connect_by_service(service_name, host=None, registrar=None, timeout=2, service=VoidService, config={}):
     """create a connection to an arbitrary server that exposes the requested service
 

--- a/rpyc/utils/factory.py
+++ b/rpyc/utils/factory.py
@@ -29,6 +29,10 @@ class DiscoveryError(Exception):
     pass
 
 
+class ForbiddenError(Exception):
+    pass
+
+
 # ------------------------------------------------------------------------------
 # API
 # ------------------------------------------------------------------------------
@@ -230,6 +234,8 @@ def list_services(registrar=None, timeout=2):
     if registrar is None:
         registrar = UDPRegistryClient(timeout=timeout)
     services = registrar.list()
+    if services is None:
+        raise ForbiddenError("Registry doesn't allow listing")
     return services
 
 

--- a/rpyc/utils/registry.py
+++ b/rpyc/utils/registry.py
@@ -31,7 +31,7 @@ REGISTRY_PORT = 18811
 class RegistryServer(object):
     """Base registry server"""
 
-    def __init__(self, listenersock, pruning_timeout=None, logger=None):
+    def __init__(self, listenersock, pruning_timeout=None, logger=None, allow_listing=False):
         self.sock = listenersock
         self.port = self.sock.getsockname()[1]
         self.active = False
@@ -41,6 +41,7 @@ class RegistryServer(object):
         self.pruning_timeout = pruning_timeout
         if logger is None:
             logger = self._get_logger()
+        self.allow_listing = allow_listing
         self.logger = logger
 
     def _get_logger(self):
@@ -99,9 +100,13 @@ class RegistryServer(object):
 
     def cmd_list(self, host):
         """ implementation fo the ``list`` command"""
+        self.logger.debug("querying for services list:")
+        if not self.allow_listing:
+            self.logger.debug("listing is disabled")
+            return None
         services = tuple(self.services.keys())
-        self.logger.debug(f"{host} request list of available services:"
-                          f"{services}")
+        self.logger.debug(f"replying with {services}")
+
         return services
 
     def cmd_register(self, host, names, port):
@@ -181,14 +186,14 @@ class UDPRegistryServer(RegistryServer):
 
     TIMEOUT = 1.0
 
-    def __init__(self, host="0.0.0.0", port=REGISTRY_PORT, pruning_timeout=None, logger=None):
+    def __init__(self, host="0.0.0.0", port=REGISTRY_PORT, pruning_timeout=None, logger=None, allow_listing=False):
         family, socktype, proto, _, sockaddr = socket.getaddrinfo(host, port, 0,
                                                                   socket.SOCK_DGRAM)[0]
         sock = socket.socket(family, socktype, proto)
         sock.bind(sockaddr)
         sock.settimeout(self.TIMEOUT)
         RegistryServer.__init__(self, sock, pruning_timeout=pruning_timeout,
-                                logger=logger)
+                                logger=logger, allow_listing=allow_listing)
 
     def _get_logger(self):
         return logging.getLogger("REGSRV/UDP/%d" % (self.port,))
@@ -211,10 +216,9 @@ class TCPRegistryServer(RegistryServer):
     TIMEOUT = 3.0
 
     def __init__(self, host="0.0.0.0", port=REGISTRY_PORT, pruning_timeout=None,
-                 logger=None, reuse_addr=True):
+                 logger=None, reuse_addr=True, allow_listing=False):
 
-        family, socktype, proto, _, sockaddr = socket.getaddrinfo(host, port, 0,
-                                                                  socket.SOCK_STREAM)[0]
+        family, socktype, proto, _, sockaddr = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)[0]
         sock = socket.socket(family, socktype, proto)
         if reuse_addr and sys.platform != "win32":
             # warning: reuseaddr is not what you expect on windows!
@@ -223,7 +227,7 @@ class TCPRegistryServer(RegistryServer):
         sock.listen(10)
         sock.settimeout(self.TIMEOUT)
         RegistryServer.__init__(self, sock, pruning_timeout=pruning_timeout,
-                                logger=logger)
+                                logger=logger, allow_listing=allow_listing)
         self._connected_sockets = {}
 
     def _get_logger(self):
@@ -271,6 +275,13 @@ class RegistryClient(object):
         :param name: the service name (or one of its aliases)
 
         :returns: a list of ``(host, port)`` tuples
+        """
+        raise NotImplementedError()
+
+    def list(self):
+        """
+        Send a query for the full lists of exposed servers
+        :returns: a list of `` service_name ``
         """
         raise NotImplementedError()
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -61,7 +61,7 @@ class BaseRegistryTest(object):
 
 class TestTcpRegistry(BaseRegistryTest, unittest.TestCase):
     def _get_server(self):
-        return TCPRegistryServer(pruning_timeout=PRUNING_TIMEOUT)
+        return TCPRegistryServer(pruning_timeout=PRUNING_TIMEOUT, allow_listing=True)
 
     def _get_client(self):
         return TCPRegistryClient("localhost")
@@ -69,7 +69,7 @@ class TestTcpRegistry(BaseRegistryTest, unittest.TestCase):
 
 class TestUdpRegistry(BaseRegistryTest, unittest.TestCase):
     def _get_server(self):
-        return UDPRegistryServer(pruning_timeout=PRUNING_TIMEOUT)
+        return UDPRegistryServer(pruning_timeout=PRUNING_TIMEOUT, allow_listing=True)
 
     def _get_client(self):
         return UDPRegistryClient()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -37,6 +37,13 @@ class BaseRegistryTest(object):
         res = c.discover("FOO")
         expected = (45678,)
         self.assertEqual(set(p for _, p in res), set(expected))
+        res = c.list()
+        expected = ("FOO",)
+        self.assertEqual(set(p for p in res), set(expected))
+        c.register(("BAR",), 54321)
+        res = c.list()
+        expected = ("FOO", "BAR")
+        self.assertEqual(set(res), set(expected))
 
     def test_pruning(self):
         c = self._get_client()


### PR DESCRIPTION
In my use case I found myself wanting to get a list of known services registered on a registry, 
and since I didn't find a clean way to do it with current registry, I decided to extend it to add this functionality.

I also added a factory method for ease of use, and updated the tests accordingly.