### PR TITLE
fixes #449

### DIFF
--- a/rpyc/core/async_.py
+++ b/rpyc/core/async_.py
@@ -1,4 +1,5 @@
 import time  # noqa: F401
+from threading import Event
 from rpyc.lib import Timeout
 from rpyc.lib.compat import TimeoutError as AsyncResultTimeout
 
@@ -12,14 +13,14 @@ class AsyncResult(object):
 
     def __init__(self, conn):
         self._conn = conn
-        self._is_ready = False
+        self._is_ready = Event()
         self._is_exc = None
         self._obj = None
         self._callbacks = []
         self._ttl = Timeout(None)
 
     def __repr__(self):
-        if self._is_ready:
+        if self._is_ready.is_set():
             state = "ready"
         elif self._is_exc:
             state = "error"
@@ -34,7 +35,7 @@ class AsyncResult(object):
             return
         self._is_exc = is_exc
         self._obj = obj
-        self._is_ready = True
+        self._is_ready.set()
         for cb in self._callbacks:
             cb(self)
         del self._callbacks[:]
@@ -43,9 +44,11 @@ class AsyncResult(object):
         """Waits for the result to arrive. If the AsyncResult object has an
         expiry set, and the result did not arrive within that timeout,
         an :class:`AsyncResultTimeout` exception is raised"""
-        while not self._is_ready and not self._ttl.expired():
-            self._conn.serve(self._ttl)
-        if not self._is_ready:
+        while not self._is_ready.is_set() and not self._ttl.expired():
+            if self._conn.serve(self._ttl) == True:
+                # we received a response, wait for the completion call
+                self._is_ready.wait()
+        if not self._is_ready.is_set():
             raise AsyncResultTimeout("result expired")
 
     def add_callback(self, func):
@@ -56,7 +59,7 @@ class AsyncResult(object):
 
         :param func: the callback function to add
         """
-        if self._is_ready:
+        if self._is_ready.is_set():
             func(self)
         else:
             self._callbacks.append(func)
@@ -72,12 +75,12 @@ class AsyncResult(object):
     @property
     def ready(self):
         """Indicates whether the result has arrived"""
-        if self._is_ready:
+        if self._is_ready.is_set():
             return True
         if self._ttl.expired():
             return False
         self._conn.poll_all()
-        return self._is_ready
+        return self._is_ready.is_set()
 
     @property
     def error(self):
@@ -87,7 +90,7 @@ class AsyncResult(object):
     @property
     def expired(self):
         """Indicates whether the AsyncResult has expired"""
-        return not self._is_ready and self._ttl.expired()
+        return not self._is_ready.is_set() and self._ttl.expired()
 
     @property
     def value(self):


### PR DESCRIPTION
I was experiencing hangs similar to #449, #437, and #354. 
The issue I was seeing is basically a race condition present in the `AsyncResult` class.
If another thread happens to get the request data in a call to `Connection.serve` then `AsyncResult.wait` will end up going around the `while not self._is_ready` loop an additional time, which is why there is a timeout on the request, but no "result expired" exception. The other thread will call the thread callback (`Connection._seq_request_callback`), but may not set `_is_ready` in time for the loop in `AsyncResult.wait` to break without re-entering `Connection.serve`. 

This PR does fix the hanging issues for my application, and I suspect it will help others as well, but I do not think it addresses the root of the problem: that other threads may call callbacks on async requests at the `Connection` level. 

This fix changes the `AsyncResult._is_ready` variable from a `bool` to a `threading.Event` and waits on it if the call to `Connection.serve` in `AsyncResult.wait` returns True (data was dispatched). 

Let me know if you have questions, comments, revisions, etc. 

Hope this helps!