### PR TITLE
utils: importer: Implement Python importlib Loader and PathFinder

### DIFF
--- a/rpyc/__init__.py
+++ b/rpyc/__init__.py
@@ -49,7 +49,7 @@ from rpyc.utils.factory import (connect_stream, connect_channel, connect_pipes,
                                 connect_stdpipes, connect, ssl_connect, list_services, discover, connect_by_service, connect_subproc,
                                 connect_thread, ssh_connect)
 from rpyc.utils.helpers import async_, timed, buffiter, BgServingThread, restricted
-from rpyc.utils import classic
+from rpyc.utils import classic, importer
 from rpyc.version import version as __version__
 
 from rpyc.lib import setup_logger, spawn

--- a/rpyc/utils/importer.py
+++ b/rpyc/utils/importer.py
@@ -1,0 +1,45 @@
+import sys
+import importlib.abc
+import importlib.util
+import importlib.machinery
+
+import rpyc.utils
+
+
+class RPyCLoader(importlib.abc.Loader):
+    def __init__(self, conn):
+        self.conn = conn
+
+    def create_module(self, spec):
+        breakpoint()
+        return
+        print(self, spec)
+        print(self.conn.modules, spec.name)
+        module = self.conn.modules[spec.name]
+        print(module.Version)
+        print(module)
+        return self.conn.modules[spec.name]
+
+    def exec_module(self, module):
+        remote_module = self.conn.modules[module.__spec__.name]
+        print("exec_module", "local", module, module.__dict__)
+        print("exec_module", "remote", remote_module, remote_module.__dict__)
+        print(module.__dict__)
+        return
+        for key in remote_module.__dict__:
+            print(key)
+            if key not in ["__spec__", "__loader__"]:
+                module.__dict__[key] == remote_module.__dict__[key]
+        print(module.__dict__)
+        return
+
+
+class RPyCPathFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, conn, loader=None):
+        self.conn = conn
+        if loader is None:
+            loader = RPyCLoader(self.conn)
+        self.loader = loader
+
+    def find_spec(self, name, path, target=None):
+        return importlib.util.spec_from_loader(name, self.loader)

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,46 @@
+import subprocess
+import sys
+import os
+import unittest
+import importlib
+
+import rpyc
+
+
+class ImporterTest(unittest.TestCase):
+    def setUp(self):
+        server_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "bin", "rpyc_classic.py")
+        self.proc = subprocess.Popen([sys.executable, server_file, "--mode=oneshot", "--host=localhost", "-p0"],
+                                     stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        line = self.proc.stdout.readline().strip()
+        if not line:
+            print(self.proc.stderr.read())
+            self.fail("server failed to start")
+        self.assertEqual(line, b"rpyc-oneshot", "server failed to start")
+        host, port = self.proc.stdout.readline().strip().split(b"\t")
+        self.conn = rpyc.classic.connect(host, int(port))
+
+    def tearDown(self):
+        self.conn.close()
+        self.proc.communicate()  # clear io so resources are closed
+
+    def test(self):
+        # Get the pid of the process running this test
+        os = importlib.import_module("os")
+        pid = os.getpid()
+        # Make RPyC finder first in line for imports
+        # sys.meta_path.insert(0, rpyc.utils.importer.RPyCPathFinder(self.conn))
+        sys.meta_path.append(rpyc.utils.importer.RPyCPathFinder(self.conn))
+        # Trigger re-import from remote
+        del sys.modules["os"]
+        importlib.invalidate_caches()
+        os = importlib.import_module("os")
+        importlib.import_module("dffml")
+        # Get the pid of the process running the classic server
+        remote_pid = os.getpid()
+        # Check that remote os module was imported by seeing if the pid changed
+        self.assertNotEqual(pid, remote_pid, "Remote os module was not loaded")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This will hopefully allow users to import remote modules transparently