### PR TITLE
Fix classic RPyC over classic RPyC bug

### DIFF
--- a/rpyc/core/service.py
+++ b/rpyc/core/service.py
@@ -137,7 +137,10 @@ class ModuleNamespace(object):
         return self.__cache[name]
 
     def __getattr__(self, name):
-        return self[name]
+        try:
+            return self[name]
+        except ImportError:
+            raise AttributeError(name)
 
 
 class Slave(object):


### PR DESCRIPTION
The implementation of ModuleNamespace's `__getattr__` may throw a `ModuleNotFoundError` when accessing an attribute.   This is unexpected behaviour and should be changed to throwing an AttributeError when an attribute is not found (as defined in [PEP 562](https://www.python.org/dev/peps/pep-0562/#id9)).  
This may cause a variety of problems, for example, when trying to connect classic RPyC over RPyc and use any module, you get a `ModuleNotFoundError`.  

In order to reproduce this error, start a slave service on localhost and execute the following code:  
```python
rpyc.classic.connect('localhost').modules.rpyc.classic.connect('localhost').modules
```