### PR TITLE
Add types.MappingProxyType to _builtin_types

### DIFF
--- a/rpyc/core/netref.py
+++ b/rpyc/core/netref.py
@@ -35,7 +35,7 @@ _builtin_types = [
     type, object, bool, complex, dict, float, int, list, slice, str, tuple, set,
     frozenset, BaseException, Exception, type(None), types.BuiltinFunctionType, types.GeneratorType,
     types.MethodType, types.CodeType, types.FrameType, types.TracebackType,
-    types.ModuleType, types.FunctionType,
+    types.ModuleType, types.FunctionType, types.MappingProxyType,
 
     type(int.__add__),      # wrapper_descriptor
     type((1).__add__),      # method-wrapper


### PR DESCRIPTION
Essentially I need it so that "isinstance(netref, types.MappingProxyType)"
will return the expected result (True) if "netref" is a netref to MappingProxyType.
After this change, it works as expected.

I can add a test (e.g of `isinstance`) but I didn't find any suitable spot for that. (I think that we don't test all types in `_builtin_types`, anyway. We might want to?)