### PR TITLE
Fix propagation of AttributeErrors raised by exposed descriptors

### DIFF
--- a/rpyc/core/protocol.py
+++ b/rpyc/core/protocol.py
@@ -525,8 +525,9 @@ class Connection(object):
             try:
                 getattr_static(obj, name)
             except AttributeError:
-                return hasattr(obj, name)
-            return True
+                return False
+            else:
+                return True
 
 
         config = self._config
@@ -537,7 +538,7 @@ class Connection(object):
         plain |= config["allow_exposed_attrs"] and name.startswith(prefix)
         plain |= config["allow_safe_attrs"] and name in config["safe_attrs"]
         plain |= config["allow_public_attrs"] and not name.startswith("_")
-        has_exposed = prefix and hasattr_static(obj, prefix + name)
+        has_exposed = prefix and (hasattr(obj, prefix + name) or hasattr_static(obj, prefix + name))
         if plain and (not has_exposed or hasattr(obj, name)):
             return name
         if has_exposed:


### PR DESCRIPTION
Closes #478.

This uses `inspect.getattr_static` to avoid triggering the descriptor lookup that `hasattr` usually triggers. The logic also needs a fallback to `hasattr` since `getattr_static` "may not be able to retrieve all attributes that `getattr` can fetch (like dynamically created attributes)".

Per the docs, `getattr_static` "may find attributes that `getattr` can’t (like descriptors that raise `AttributeError`)". I am not aware of any edge cases where `hasattr` will return False but where `getattr_static` will succeed without raising an `AttributeError` (although I did not not dive into CPython's `getattr_static` implementation to look for such cases), but perhaps there is some edge case that makes using `getattr_static` a bad choice here. If you know of a better way to fix #478 please let me know :)

I was a bit liberal with adding the tests for multiple configs since the runtime it adds is negligible and extra safety is good. I also slightly broke PEP 8 line length in the tests I added—please change my code style if RPyC uses a different style :)