### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(name="rpyc",
       maintainer_email="james@network-perception.com",
       license="MIT",
       url="http://rpyc.readthedocs.org",
+      project_urls={
+        "Source": "https://github.com/tomerfiliba-org/rpyc",
+      },
       packages=[
           'rpyc',
           'rpyc.core',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)