### PR TITLE
Add a configurable timeout on the zerodeploy close() method

### DIFF
--- a/docs/docs/zerodeploy.rst
+++ b/docs/docs/zerodeploy.rst
@@ -114,4 +114,8 @@ under the user's permissions. You can connect as an unprivileged user to make su
 ``rm -rf /``. Second, it creates an SSH tunnel for the transport, so everything is kept encrypted on the wire.
 And you get these features for free -- just configuring SSH accounts will do.
 
-
+Timeouts
+--------
+You can pass a ``timeout`` argument, in seconds, to the ``close()`` method.  A ``TimeoutExpired`` is raised if
+any subprocess communication takes longer than the timeout, after the subprocess has been told to terminate.  By
+default, the timeout is four minutes.  The timeout prevents a ``close()`` call blocking indefinitely.

--- a/docs/docs/zerodeploy.rst
+++ b/docs/docs/zerodeploy.rst
@@ -118,4 +118,5 @@ Timeouts
 --------
 You can pass a ``timeout`` argument, in seconds, to the ``close()`` method.  A ``TimeoutExpired`` is raised if
 any subprocess communication takes longer than the timeout, after the subprocess has been told to terminate.  By
-default, the timeout is four minutes.  The timeout prevents a ``close()`` call blocking indefinitely.
+default, the timeout is ``None`` i.e. infinite.  A timeout value prevents a ``close()`` call blocking
+indefinitely.

--- a/rpyc/utils/zerodeploy.py
+++ b/rpyc/utils/zerodeploy.py
@@ -152,7 +152,7 @@ class DeployedServer(object):
     def __exit__(self, t, v, tb):
         self.close()
 
-    def close(self, timeout=4*60):
+    def close(self, timeout=None):
         if self.proc is not None:
             try:
                 self.proc.terminate()

--- a/rpyc/utils/zerodeploy.py
+++ b/rpyc/utils/zerodeploy.py
@@ -4,6 +4,7 @@
 Requires [plumbum](http://plumbum.readthedocs.org/)
 """
 from __future__ import with_statement
+from subprocess import TimeoutExpired
 import sys
 import socket  # noqa: F401
 from rpyc.lib.compat import BYTES_LITERAL
@@ -151,27 +152,36 @@ class DeployedServer(object):
     def __exit__(self, t, v, tb):
         self.close()
 
-    def close(self):
+    def close(self, timeout=4*60):
         if self.proc is not None:
             try:
                 self.proc.terminate()
-                self.proc.communicate()
+                self.proc.communicate(timeout=timeout)
+            except TimeoutExpired:
+                self.proc.kill()
+                raise
             except Exception:
                 pass
             self.proc = None
         if self.tun is not None:
             try:
                 self.tun._session.proc.terminate()
-                self.tun._session.proc.communicate()
+                self.tun._session.proc.communicate(timeout=timeout)
                 self.tun.close()
+            except TimeoutExpired:
+                self.tun._session.proc.kill()
+                raise
             except Exception:
                 pass
             self.tun = None
         if self.remote_machine is not None:
             try:
                 self.remote_machine._session.proc.terminate()
-                self.remote_machine._session.proc.communicate()
+                self.remote_machine._session.proc.communicate(timeout=timeout)
                 self.remote_machine.close()
+            except TimeoutExpired:
+                self.remote_machine._session.proc.kill()
+                raise
             except Exception:
                 pass
             self.remote_machine = None

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,6 +1,9 @@
 from __future__ import with_statement
+
 import unittest
+import subprocess
 import sys
+
 from plumbum import SshMachine
 from plumbum.machines.paramiko_machine import ParamikoMachine
 from rpyc.utils.zerodeploy import DeployedServer
@@ -11,7 +14,6 @@ except Exception:
     _paramiko_import_failed = True
 
 
-@unittest.skipIf(_paramiko_import_failed, "Paramiko is not available")
 class TestDeploy(unittest.TestCase):
     def test_deploy(self):
         rem = SshMachine("localhost")
@@ -30,6 +32,51 @@ class TestDeploy(unittest.TestCase):
             self.fail("expected an EOFError")
         rem.close()
 
+    def test_close_timeout(self):
+        expected_timeout = 4
+        observed_timeouts = []
+        original_communicate = subprocess.Popen.communicate
+
+        def replacement_communicate(self, input=None, timeout=None):
+            observed_timeouts.append(timeout)
+            return original_communicate(self, input, timeout)
+
+        try:
+            subprocess.Popen.communicate = replacement_communicate
+            rem = SshMachine("localhost")
+            SshMachine.python = rem[sys.executable]
+            dep = DeployedServer(rem)
+            dep.classic_connect()
+            dep.close(timeout=expected_timeout)
+            rem.close()
+        finally:
+            subprocess.Popen.communicate = original_communicate
+        # The last three calls to communicate() happen during close(), so check they
+        # applied the timeout.
+        assert observed_timeouts[-3:] == [expected_timeout] * 3
+
+    def test_close_timeout_default_none(self):
+        observed_timeouts = []
+        original_communicate = subprocess.Popen.communicate
+
+        def replacement_communicate(self, input=None, timeout=None):
+            observed_timeouts.append(timeout)
+            return original_communicate(self, input, timeout)
+
+        try:
+            subprocess.Popen.communicate = replacement_communicate
+            rem = SshMachine("localhost")
+            SshMachine.python = rem[sys.executable]
+            dep = DeployedServer(rem)
+            dep.classic_connect()
+            dep.close()
+            rem.close()
+        finally:
+            subprocess.Popen.communicate = original_communicate
+        # No timeout specified, so Popen.communicate should have been called with timeout None.
+        assert observed_timeouts == [None] * len(observed_timeouts)
+
+    @unittest.skipIf(_paramiko_import_failed, "Paramiko is not available")
     def test_deploy_paramiko(self):
         rem = ParamikoMachine("localhost", missing_host_policy=paramiko.AutoAddPolicy())
         with DeployedServer(rem) as dep:


### PR DESCRIPTION
We observed rpyc zerodeploy getting stuck on the `close()` method when running under Jenkins.  Specifically, the following  line from `zerodeploy.py` blocked indefinitely.
```
self.tun._session.proc.communicate()
```

This change adds a configurable timeout to the close() method, with default value 4 minutes, which is surely enough time to wait for anything to close.  It makes it easier to debug issues when closing because it raises an exception with the stack trace, rather than blocking indefinitely with no logs printed.