### PR TITLE
Changes related to SSL context

### DIFF
--- a/rpyc/core/stream.py
+++ b/rpyc/core/stream.py
@@ -206,20 +206,32 @@ class SocketStream(Stream):
 
         :returns: a :class:`SocketStream`
         """
-        from ssl import SSLContext
         import ssl
         if kwargs.pop("ipv6", False):
             kwargs["family"] = socket.AF_INET6
         s = cls._connect(host, port, **kwargs)
         try:
-            context = SSLContext(ssl_kwargs.pop('ssl_version'))
-            certfile = ssl_kwargs.pop('certfile', None)
-            keyfile = ssl_kwargs.pop('keyfile', None)
+            if "ssl_version" in ssl_kwargs:
+                context = ssl.SSLContext(ssl_kwargs.pop("ssl_version"))
+            else:
+                context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+            certfile = ssl_kwargs.pop("certfile", None)
+            keyfile = ssl_kwargs.pop("keyfile", None)
             if certfile is not None:
                 context.load_cert_chain(certfile, keyfile=keyfile)
-            context.check_hostname = ssl_kwargs.pop('check_hostname', True)
-            context.verify_mode = ssl_kwargs.pop('cert_reqs', ssl.CERT_NONE)
-            s2 = context.wrap_socket(s, **ssl_kwargs)
+            ca_certs = ssl_kwargs.pop("ca_certs", None)
+            if ca_certs is not None:
+                context.load_verify_locations(ca_certs)
+            ciphers = ssl_kwargs.pop("ciphers", None)
+            if ciphers is not None:
+                context.set_ciphers(ciphers)
+            check_hostname = ssl_kwargs.pop("check_hostname", None)
+            if check_hostname is not None:
+                context.check_hostname = check_hostname
+            cert_reqs = ssl_kwargs.pop("cert_reqs", None)
+            if cert_reqs is not None:
+                context.verify_mode = cert_reqs
+            s2 = context.wrap_socket(s, server_hostname=host, **ssl_kwargs)
             return cls(s2)
         except BaseException:
             s.close()


### PR DESCRIPTION
Fixes https://github.com/tomerfiliba-org/rpyc/issues/486 (introduced with python 3.10)

- `SocketStream.ssl_connect` now handles all arguments correctly (`ca_certs` and `ciphers` were incorrectly passed to `context.wrap_socket`)
- `SSLAuthenticator` now also uses `SSLContext` which enables hostname check (see https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname)
- Both now rely on `ssl.create_default_context` to set reasonable defaults for `ssl_version` and `cert_reqs`. Former defaults led to inconsistencies (issue 486 is due to deprecation of `PROTOCOL_TLS` in python 3.10; `check_hostname` is enabled by default in python 3.10 conflicting with former default `REQ_NONE`)

I ran the ssl unittest with python 3.6 to check backwards compat