### PR TITLE
Fix race condition in AsyncResult.wait

### DIFF
--- a/rpyc/core/async_.py
+++ b/rpyc/core/async_.py
@@ -13,14 +13,14 @@ class AsyncResult(object):
 
     def __init__(self, conn):
         self._conn = conn
-        self._is_ready = Event()
+        self._is_ready = False
         self._is_exc = None
         self._obj = None
         self._callbacks = []
         self._ttl = Timeout(None)
 
     def __repr__(self):
-        if self._is_ready.is_set():
+        if self._is_ready:
             state = "ready"
         elif self._is_exc:
             state = "error"
@@ -35,7 +35,7 @@ class AsyncResult(object):
             return
         self._is_exc = is_exc
         self._obj = obj
-        self._is_ready.set()
+        self._is_ready = True
         for cb in self._callbacks:
             cb(self)
         del self._callbacks[:]
@@ -44,9 +44,13 @@ class AsyncResult(object):
         """Waits for the result to arrive. If the AsyncResult object has an
         expiry set, and the result did not arrive within that timeout,
         an :class:`AsyncResultTimeout` exception is raised"""
-        while not self._is_ready.is_set() and not self._ttl.expired():
-            self._conn.serve(self._ttl)
-        if not self._is_ready.is_set():
+        while not (self._is_ready or self._ttl.expired()):
+            self._conn._recvlock.acquire()
+            if self._is_ready or self._ttl.expired():
+                self._conn._recvlock.release()
+                break
+            self._conn.serve(self._ttl, lock_extended=True)
+        if not self._is_ready:
             raise AsyncResultTimeout("result expired")
 
     def add_callback(self, func):
@@ -57,7 +61,7 @@ class AsyncResult(object):
 
         :param func: the callback function to add
         """
-        if self._is_ready.is_set():
+        if self._is_ready:
             func(self)
         else:
             self._callbacks.append(func)
@@ -73,12 +77,12 @@ class AsyncResult(object):
     @property
     def ready(self):
         """Indicates whether the result has arrived"""
-        if self._is_ready.is_set():
+        if self._is_ready:
             return True
         if self._ttl.expired():
             return False
         self._conn.poll_all()
-        return self._is_ready.is_set()
+        return self._is_ready
 
     @property
     def error(self):
@@ -88,7 +92,7 @@ class AsyncResult(object):
     @property
     def expired(self):
         """Indicates whether the AsyncResult has expired"""
-        return not self._is_ready.is_set() and self._ttl.expired()
+        return not self._is_ready and self._ttl.expired()
 
     @property
     def value(self):


### PR DESCRIPTION
Fixes https://github.com/tomerfiliba-org/rpyc/issues/354 (and maybe more)

- The receive lock is extended in both directions to cover `AsyncResult.wait`
- `data` is split to allow lock release as soon as possible

I can consistently reproduce issue 354 and provide an example if requested.