### PR TITLE
docs: fix simple typo, credentails -> credentials

### DIFF
--- a/rpyc/core/protocol.py
+++ b/rpyc/core/protocol.py
@@ -109,7 +109,7 @@ Parameter                                Default value     Description
 
 ``connid``                               ``None``          **Runtime**: the RPyC connection ID (used
                                                            mainly for debugging purposes)
-``credentials``                          ``None``          **Runtime**: the credentails object that was returned
+``credentials``                          ``None``          **Runtime**: the credentials object that was returned
                                                            by the server's :ref:`authenticator <api-authenticators>`
                                                            or ``None``
 ``endpoints``                            ``None``          **Runtime**: The connection's endpoints. This is a tuple


### PR DESCRIPTION
There is a small typo in rpyc/core/protocol.py.

Should read `credentials` rather than `credentails`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md