### PR TITLE
teleporation: Support Py3.11

### DIFF
--- a/rpyc/lib/compat.py
+++ b/rpyc/lib/compat.py
@@ -6,6 +6,7 @@ import sys
 import time
 
 is_py_3k = (sys.version_info[0] >= 3)
+is_py_gte311 = is_py_3k and (sys.version_info[1] >= 11)
 is_py_gte38 = is_py_3k and (sys.version_info[1] >= 8)
 is_py_gte37 = is_py_3k and (sys.version_info[1] >= 7)
 

--- a/rpyc/lib/compat.py
+++ b/rpyc/lib/compat.py
@@ -7,6 +7,7 @@ import time
 
 is_py_3k = (sys.version_info[0] >= 3)
 is_py_gte311 = is_py_3k and (sys.version_info[1] >= 11)
+is_py_gte310 = is_py_3k and (sys.version_info[1] >= 10)
 is_py_gte38 = is_py_3k and (sys.version_info[1] >= 8)
 is_py_gte37 = is_py_3k and (sys.version_info[1] >= 7)
 


### PR DESCRIPTION
Closes: https://github.com/tomerfiliba-org/rpyc/issues/513

Open points:
* [ ] unlike the py38 diff with older versions (`posonlyargs`), the fields added in py311 play a more important role and I haven't tested yet if a function teleported from e.g 3.8 to 3.11 will behave correctly despite `co_exceptiontable` not initialized properly.
* [ ] `co_qualname` can use `co_name` if missing (e.g 3.8 -> 3.11 teleportation)
* [ ] `test_teleportation.py::test_compat` is broken, it works on the assumption that `CodeType` was broken only on 3.8, and requires a redesign to work properly on 3.11 era, I think (it currently tests 4 permutations and it will have to test 9 with 3.11)

Otherwise - all local, same-version tests are passing, so this can be safely used 3.11 <-> 3.11 I think, and also teleportations of 3.11 -> lower can be used (but not the other way around until the points I mentioned are investigated).