### PR TITLE
Increased thread id struct to work on 64bit Linux, fixes #524

### DIFF
--- a/rpyc/core/brine.py
+++ b/rpyc/core/brine.py
@@ -56,9 +56,11 @@ F8 = Struct("!d")  # Python type float w/ size [8] (ctype double)
 C16 = Struct("!dd")  # Successive floats (complex numbers)
 I1 = Struct("!B")  # Python type int w/ size [1] (ctype unsigned char)
 I4 = Struct("!L")  # Python type int w/ size [4] (ctype unsigned long)
-# I4I4 is successive ints w/ size 4 and was introduced to pack local thread id and remote thread id
-# Since PyThread_get_thread_ident returns a type of unsigned long, !LL can store both thread IDs.
-I4I4 = Struct("!LL")
+# I8I8 is successive ints w/ size 8 and was introduced to pack local thread id and remote thread id
+# PyThread_get_thread_ident returns a type of unsigned long, with platform dependent size.
+# Use 8 byte length such that this also works on Unix 64-bit systems, see:
+# https://en.wikipedia.org/wiki/Integer_(computer_science)#Long_integer 
+I8I8 = Struct("!QQ")
 
 _dump_registry = {}
 _load_registry = {}

--- a/rpyc/core/brine.py
+++ b/rpyc/core/brine.py
@@ -56,10 +56,12 @@ F8 = Struct("!d")  # Python type float w/ size [8] (ctype double)
 C16 = Struct("!dd")  # Successive floats (complex numbers)
 I1 = Struct("!B")  # Python type int w/ size [1] (ctype unsigned char)
 I4 = Struct("!L")  # Python type int w/ size [4] (ctype unsigned long)
-# I8I8 is successive ints w/ size 8 and was introduced to pack local thread id and remote thread id
-# PyThread_get_thread_ident returns a type of unsigned long, with platform dependent size.
-# Use 8 byte length such that this also works on Unix 64-bit systems, see:
-# https://en.wikipedia.org/wiki/Integer_(computer_science)#Long_integer 
+# I8I8 is successive ints w/ size 8 and was introduced to pack local thread id and remote thread id. Since
+# PyThread_get_thread_ident returns a type of unsigned long, a platform dependent size, we
+# need 8 bytes of length to support LP64/64-bit platforms. See
+#  - https://unix.org/whitepapers/64bit.html
+#  - https://en.wikipedia.org/wiki/Integer_(computer_science)#Long_integer
+# TODO: Switch to native_id when 3.7 is EOL b/c PyThread_get_thread_ident is inheritly hosed due to casting.
 I8I8 = Struct("!QQ")
 
 _dump_registry = {}

--- a/rpyc/core/protocol.py
+++ b/rpyc/core/protocol.py
@@ -260,7 +260,7 @@ class Connection(object):
         data = brine.dump((msg, seq, args))
         if self._bind_threads:
             this_thread = self._get_thread()
-            data = brine.I4I4.pack(this_thread.id, this_thread._remote_thread_id) + data
+            data = brine.I8I8.pack(this_thread.id, this_thread._remote_thread_id) + data
             if msg == consts.MSG_REQUEST:
                 this_thread._occupation_count += 1
             else:
@@ -549,7 +549,7 @@ class Connection(object):
 
                 return False
 
-            remote_thread_id, local_thread_id = brine.I4I4.unpack(message[:16])
+            remote_thread_id, local_thread_id = brine.I8I8.unpack(message[:16])
             message = message[16:]
 
             this = False


### PR DESCRIPTION
Fixes #524 

Increase size of the struct which holds the threads id's, because these are 8 bytes long on 64bit Linux.

This allows the `bind_threads` option to work on Linux, but will break compatibility with any previous version of `rpyc`.

In `rpyc/core/protocol.py`:

```
 remote_thread_id, local_thread_id = brine.I4I4.unpack(message[:16])
 message = message[16:]
```
I am not sure why you used `16`, since the `'!LL'` struct should only be 8 bytes long. But this is the right size for the `'!QQ'` struct